### PR TITLE
fixed video background and anothers

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -2,7 +2,7 @@
   /* 상단 header */
   .gnb {
     background:
-    linear-gradient(to right, #ffffff calc(25% - 23rem), transparent 0%),
+    linear-gradient(to right, #ffffff calc(25% - 20rem), transparent 0%),
     linear-gradient(to bottom, var(--primary-hw) 50%, transparent 0%);
     background-size: 200% 200%;
     background-position: 100% 100%;

--- a/assets/css/landing/infomation.css
+++ b/assets/css/landing/infomation.css
@@ -3,32 +3,6 @@
     background-color: transparent;
   }
 
-  /* infomation background zoomin animation */
-  .infomation::after{
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: inherit;
-    background-size: cover;
-    transform-origin: center;
-    transition: transform 0.4s ease-in-out;
-    transform: scale(1.1);
-    animation: infomation-zoomin 60s ease;
-    animation-fill-mode: forwards;
-  }
-
-  @keyframes infomation-zoomin {
-    from {
-      transform: scale(1.1);
-    }
-    to {
-      transform: scale(1);
-    }
-  }
-
   /* 랜딩페이지 infomation의 text 나타나는 효과 */
   .infomation-char span {
     opacity: 0;

--- a/components/header/pc.vue
+++ b/components/header/pc.vue
@@ -14,7 +14,7 @@ const store = useUiStore() // ui store
 </script>
 <template>
   <div
-    class="flex-auto items-baseline justify-between duration-300"
+    class="flex-auto items-baseline justify-end duration-300 gap-5"
   >
     <section
       class="flex mt-8"

--- a/components/landing/capabilities.vue
+++ b/components/landing/capabilities.vue
@@ -45,10 +45,10 @@ onMounted(() => {
 
 <template>
   <div class="relative">
-    <div class="flex 2xl:w-[50vw] w-full h-screen ml-auto items-center justify-center bg-black bg-opacity-50 absolute top-0 right-0 z-20">
-      <section class="w-4/5">
+    <div class="flex 2xl:w-[50vw] w-full h-screen ml-auto items-center 2xl:justify-start justify-center bg-black bg-opacity-50 absolute top-0 right-0 z-20">
+      <section class="2xl:ml-40">
         <h2 class="text-6xl text-white font-black leading-snug 2xl:text-right">Capabilities</h2>
-        <ul class="grid grid-cols-3 2xl:w-[30rem] w-full mt-16 ml-auto gap-[2px]">
+        <ul class="grid grid-cols-3 2xl:w-[30rem] w-full mt-16 gap-[2px]">
           <li
             class="lg:h-44 md:h-40 h-36 bg-gray-600 duration-500"
             :class="{'capabilities-active': active == list.title}"

--- a/components/landing/infomation.vue
+++ b/components/landing/infomation.vue
@@ -15,16 +15,13 @@ const contents = [ // content 애니메이션 요소들 배열 item마다 newlin
 
 <template>
   <div>
-    <div class="relative w-full h-full min-w-full min-h-full -z-10">
-      <video class=" min-h-full min-w-full w-full h-full -z-10 " autoplay loop muted>
+    <div class="h-screen relative overflow-hidden">
+      <video class="w-full h-screen object-cover absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" autoplay loop muted>
         <source src="/media/intro.mp4" type="video/mp4">
-        <!-- 다른 동영상 포맷을 지원하려면 여기에 추가합니다 -->
       </video>
-    </div>
-    <div class="absolute left-20 top-0 overflow-visible z-10">
-      <div class="container mx-auto relative">
+      <div class="container mx-auto pt-80 relative">
         <div
-          class="absolute top-[30vh] left-0 z-10"
+          class="pl-8"
         >
           <section
             class="grid leading-loose 2xl:px-0 px-5 2xl:text-6xl/[5rem]  text-4xl text-white font-black"
@@ -34,7 +31,7 @@ const contents = [ // content 애니메이션 요소들 배열 item마다 newlin
               v-for="text in heading"
             >
               <span
-                class="block"
+                class="block drop-shadow-lg"
                 v-for="(word, index) in text.split('')"
                 :style="`animation-delay: ${index * 0.05}s`"
               >{{ word }}</span>
@@ -50,7 +47,7 @@ const contents = [ // content 애니메이션 요소들 배열 item마다 newlin
               v-for="text in contents"
             >
               <span
-                class="block"
+                class="block drop-shadow-lg"
                 v-for="(word, index) in text.split('')"
                 :style="`animation-delay: ${1 + (index * 0.05)}s`"
               >{{ word }}</span>

--- a/components/layout/header.vue
+++ b/components/layout/header.vue
@@ -36,7 +36,7 @@ const color = computed(() => { // header의 로고 이미지 색상
       'opacity-0': store.landing.scrollIndex > 4,
     }"
   >
-    <div class="2xl:container flex mx-32 gap-5 relative 2xl:items-start items-center 2xl:justify-start justify-between">
+    <div class="container flex gap-5 relative 2xl:items-start items-center 2xl:justify-start justify-between">
       <a
         class="flex w-96"
         href="/"


### PR DESCRIPTION
- infomation 배경에 video의 크기 지정
- video가 background로 들어가기 때문에 과거 사용한 background absolute 코드 및 애니메이션 모두 삭제
- pc header의 로고 배경 크기를 늘림 기존 메뉴 오른쪽 여백을 모두 배경에 할당
- capabilities의 정렬 기준을 왼쪽으로 이동